### PR TITLE
Update PDF styles

### DIFF
--- a/templates/reports/_styles.html
+++ b/templates/reports/_styles.html
@@ -43,7 +43,8 @@ body > *:last-child {
    margin-bottom: 0 !important; }
 
 a {
-   color: #4183C4; }
+   color: #4183C4;
+   text-decoration: none; }
 a.absent {
    color: #cc0000; }
 a.anchor {


### PR DESCRIPTION
Given the example report, I was only able to find one change needed in `_styles.html`, removing underlines from anchor tags.

The background color inside the box on page 1 is coming from inline styles in the HTML report itself.